### PR TITLE
Johnfreeman/merge fddaq v5.3.2 rc2 a9 into develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
-project(oksdalgen VERSION 1.3.0)
+project(oksdalgen VERSION 1.3.1)
 
 find_package(daq-cmake REQUIRED)
 

--- a/apps/oksdalgen.cxx
+++ b/apps/oksdalgen.cxx
@@ -900,30 +900,17 @@ gen_cpp_body(const oks::OksClass *cl, std::ostream& cpp_s, const std::string& cp
     }
 
 
+  if ( !cl->get_is_abstract() ) {
   cpp_s
     << dx << "  // the factory initializer\n\n"
     << dx << "static struct __" << name << "_Registrator\n"
     << dx << "  {\n"
     << dx << "    __" << name << "_Registrator()\n"
-  //   << dx << "      {\n"
-  //   << dx << "        dunedaq::conffwk::DalFactory::instance().register_dal_class<" << name << ">(\"" << cl->get_name() << "\", {";
-
-  //   {
-  //     bool is_first = true;
-  //     set2out(cpp_s, algo_1_set, is_first);
-  //     set2out(cpp_s, algo_n_set, is_first);
-  //   }
-
-  // cpp_s
-  //   << "});\n"
-  //   << dx << "      }\n"
-  //   << dx << "  } registrator;\n\n\n";
-
     << dx << "      {\n"
-    << dx << "        dunedaq::conffwk::DalFactory::instance().register_dal_class_2g<" << name << ">(\"" << cl->get_name() << "\");\n"
+    << dx << "        dunedaq::conffwk::DalFactory::instance().register_dal_class<" << name << ">(\"" << cl->get_name() << "\");\n"
     << dx << "      }\n"
     << dx << "  } registrator;\n\n\n";
-
+  }
 
     // the constructor
 


### PR DESCRIPTION
In light of the second fddaq-v5.3.2 candidate release, fddaq-v5.3.2-rc2-a9, this PR will merge in the changes from the patch/fddaq-v5.3.x branch of this repo (with any conflicts resolved, if needed, on this source branch for this PR
johnfreeman/merge_fddaq-v5.3.2-rc2-a9_into_develop). A test build using this branch is available at NFDT_DEV_250603_A9.

Merging is only to be done by Software Coordination.