### PR TITLE
Allow methods to be marked as protected rather than public

### DIFF
--- a/apps/oksdalgen.cxx
+++ b/apps/oksdalgen.cxx
@@ -51,6 +51,7 @@ extern std::string get_member_initializer_list(oks::OksMethodImplementation * mi
 extern std::string get_method_implementation_body(oks::OksMethodImplementation * mi);
 extern bool get_add_algo_1(oks::OksMethodImplementation * mi);
 extern bool get_add_algo_n(oks::OksMethodImplementation * mi);
+extern bool get_method_protected(oks::OksMethodImplementation * mi);
 extern oks::OksMethodImplementation * find_cpp_method_implementation(const oks::OksMethod * method);
 
 
@@ -681,6 +682,11 @@ gen_header(const oks::OksClass *cl,
                   cpp_file << "\n\n";
                 }
 
+              auto protected_method = get_method_protected(mi);
+              if (protected_method)
+                {
+                  cpp_file << dx << "protected:\n";
+                }
               // generate description
 
               print_description(cpp_file, i->get_description(), dx2);
@@ -698,6 +704,12 @@ gen_header(const oks::OksClass *cl,
                   cpp_file << "\n" << "      // extension of method " << cl->get_name() << "::" << i->get_name() << "()\n";
                   print_indented(cpp_file, public_method_extension, "    ");
                 }
+
+              if (protected_method)
+                {
+                  cpp_file << "\n" <<  dx << "public:\n";
+                }
+
             }
 
         }

--- a/apps/utils.cpp
+++ b/apps/utils.cpp
@@ -684,6 +684,7 @@ const std::string begin_member_initializer_list("BEGIN_MEMBER_INITIALIZER_LIST")
 const std::string end_member_initializer_list("END_MEMBER_INITIALIZER_LIST");
 const std::string has_add_algo_1("ADD_ALGO_1");
 const std::string has_add_algo_n("ADD_ALGO_N");
+const std::string method_protected("METHOD_PROTECTED");
 
 static std::string
 get_method_header_x_logue(OksMethodImplementation * mi, const std::string& begin, const std::string& end)
@@ -713,6 +714,13 @@ std::string
 get_public_section(OksMethodImplementation * mi)
 {
   return get_method_header_x_logue(mi, begin_public_section, end_public_section);
+}
+
+bool
+get_method_protected(OksMethodImplementation * mi)
+{
+  std::string::size_type begix_idx = mi->get_body().find(method_protected, 0);
+  return (begix_idx != std::string::npos);
 }
 
 std::string
@@ -768,6 +776,7 @@ get_method_implementation_body(OksMethodImplementation * mi)
   remove_string_section(s, begin_member_initializer_list, end_member_initializer_list);
   remove_string_section(s, has_add_algo_1, "");
   remove_string_section(s, has_add_algo_n, "");
+  remove_string_section(s, method_protected, "");
 
   if(std::all_of(s.begin(),s.end(),isspace))
     return "";


### PR DESCRIPTION
# Description

Add a keyword that can be used in the body of a method to mark the method as being in the protected rather than public scope.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature or enhancement (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking change that improves code/performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Testing checklist

- [ ] Unit tests pass (e.g. `dbt-build --unittest`)
- [ ] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [ ] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
- [ ] Python tests pass if applicable (e.g. `python -m pytest`)
- [ ] Pre-commit hooks run successfully if applicable (e.g. `pre-commit run --all-files`)

_Comments here on the testing_

## Further checks

- [ ] Code is commented where needed, particularly in hard-to-understand areas
- [ ] Code style is correct (`dbt-build --lint`, and/or see https://dune-daq-sw.readthedocs.io/en/latest/packages/styleguide/)
- [ ] If applicable, new tests have been added or an issue has been opened to tackle that in the future.
  (Indicate issue here: # (issue))

